### PR TITLE
[Proposal] Verbose config set

### DIFF
--- a/commandline/src/commands/config_set.php
+++ b/commandline/src/commands/config_set.php
@@ -22,6 +22,8 @@ return array(
 			'configs' => $configs_to_add
 		));
 
+		echo "New config sent to ".$client->getEndpoint()."." . PHP_EOL."...".PHP_EOL;
+
 		// Run 'config' command after config:add
 		$commands['config']['run']($args);
 	}


### PR DESCRIPTION
Acharia interessante declarar que ao dar um `dl-api config:set` a configuração vai ser enviada para o server. De inicio achava que a **config** se tratava apenas para o console da dl-api.

Minha sugestão seria colocar abaixo de :
https://github.com/doubleleft/dl-api/blob/master/commandline/src/commands/config_set.php#L21-L23
